### PR TITLE
Removed googlecharts from Gemfile.lock.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,6 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-protobuf (3.6.1)
-    googlecharts (1.6.12)
     guard (2.16.2)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -593,7 +592,6 @@ DEPENDENCIES
   gdata
   geckodriver-helper (~> 0.0.3)
   gherkin
-  googlecharts
   guard-rails
   guard-rspec
   haml-rails


### PR DESCRIPTION
Updated Gemfile.lock to no longer refer to googlecharts gem.
